### PR TITLE
fix: rate() no longer mutates model.limit_sigma on each call

### DIFF
--- a/openskill/models/weng_lin/bradley_terry_full.py
+++ b/openskill/models/weng_lin/bradley_terry_full.py
@@ -640,10 +640,9 @@ class BradleyTerryFull:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/bradley_terry_part.py
+++ b/openskill/models/weng_lin/bradley_terry_part.py
@@ -646,10 +646,9 @@ class BradleyTerryPart:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/plackett_luce.py
+++ b/openskill/models/weng_lin/plackett_luce.py
@@ -641,10 +641,9 @@ class PlackettLuce:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/thurstone_mosteller_full.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_full.py
@@ -661,10 +661,9 @@ class ThurstoneMostellerFull:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/thurstone_mosteller_part.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_part.py
@@ -667,10 +667,9 @@ class ThurstoneMostellerPart:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/tests/models/weng_lin/test_bradley_terry_full.py
+++ b/tests/models/weng_lin/test_bradley_terry_full.py
@@ -462,6 +462,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_bradley_terry_part.py
+++ b/tests/models/weng_lin/test_bradley_terry_part.py
@@ -482,6 +482,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_plackett_luce.py
+++ b/tests/models/weng_lin/test_plackett_luce.py
@@ -460,6 +460,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_thurstone_mosteller_full.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_full.py
@@ -469,6 +469,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_thurstone_mosteller_part.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_part.py
@@ -490,6 +490,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]


### PR DESCRIPTION
## Summary

- `rate(..., limit_sigma=True)` was writing the argument back onto `self.limit_sigma`, permanently mutating the model instance
- Every subsequent `rate()` call on that model would silently apply `limit_sigma=True` even when the argument was omitted
- Fix: use a local `_limit_sigma` variable that merges the per-call override with `self.limit_sigma` without touching the instance — applied to all five Weng-Lin model classes

## Affected files

- `openskill/models/weng_lin/bradley_terry_full.py`
- `openskill/models/weng_lin/bradley_terry_part.py`
- `openskill/models/weng_lin/plackett_luce.py`
- `openskill/models/weng_lin/thurstone_mosteller_full.py`
- `openskill/models/weng_lin/thurstone_mosteller_part.py`

## Test plan

- [ ] Added regression assertion in each model's `test_rate()`: call `rate([[a], [b]], limit_sigma=True)` then assert `model.limit_sigma is False`
- [ ] `python -m pytest tests/models/weng_lin/ -q` → 716 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)